### PR TITLE
Fix license problems while still discouraging illegal use

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,16 +1,19 @@
-This is free and unencumbered software released into the public domain,
-under the following conditions:
+The authors of this software recognize that most technologies can be
+used for lawful and unlawful purposes. The authors request that this
+software not be used to violate any local laws. The authors recognize
+that this is public domain code, that they have no real power
+to dictate how it is used other than a polite non-binding request,
+and therefore that they cannot be held responsible for what anyone
+chooses to do with it.
 
-The software must not be used or distributed in binary or source form
-for the intention of circumventing Intellectual Property laws in any 
-jurisdictions that recognize copyright laws, nor can it be used for 
-the intention of downloading copywrited content which is not released
-in the Public Domain.
+---
+
+This is free and unencumbered software released into the public domain.
 
 Anyone is free to copy, modify, publish, use, compile, sell, or
 distribute this software, either in source code form or as a compiled
 binary, for any purpose, commercial or non-commercial, and by any
-means, with the exception of the aforementioned conditions. 
+means.
 
 In jurisdictions that recognize copyright laws, the author or authors
 of this software dedicate any and all copyright interest in the
@@ -27,3 +30,5 @@ IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
 OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>


### PR DESCRIPTION
### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

There are a few problems with the modifications made to the public domain dedication found in `LICENSE`.

* it can't be public domain and also have restrictions.
* the new license means it's no longer free/FOSS/open source software.
* RIAA only cares about the links in the test script (for some reason), not the license.
* the way the license is written you can't use youtube-dl unless content is public domain, regardless of any other license you might have to the content (such as Creative Commons or purchasing a commercial license to some content).

It's up to the users to follow any relevant laws. I have restored the original public domain dedication that the youtube-dl contributors unlicensed their code with, and added a request (not a condition) that users not use the code for anything illegal.