### PR TITLE
Add download mirror links

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,18 @@ To install it right away for all UNIX users (Linux, macOS, etc.), type:
 
     sudo curl -L https://yt-dl.org/downloads/latest/youtube-dl -o /usr/local/bin/youtube-dl
     sudo chmod a+rx /usr/local/bin/youtube-dl
+    
+Mirror:
+    
+    sudo curl -L https://dl.netsyms.net/programs/youtube-dl/latest/youtube-dl -o /usr/local/bin/youtube-dl
+    sudo chmod a+rx /usr/local/bin/youtube-dl
 
 If you do not have curl, you can alternatively use a recent wget:
 
     sudo wget https://yt-dl.org/downloads/latest/youtube-dl -O /usr/local/bin/youtube-dl
     sudo chmod a+rx /usr/local/bin/youtube-dl
 
-Windows users can [download an .exe file](https://yt-dl.org/latest/youtube-dl.exe) and place it in any location on their [PATH](https://en.wikipedia.org/wiki/PATH_%28variable%29) except for `%SYSTEMROOT%\System32` (e.g. **do not** put in `C:\Windows\System32`).
+Windows users can [download an .exe file](https://yt-dl.org/latest/youtube-dl.exe) ([mirror](https://dl.netsyms.net/programs/youtube-dl/latest/youtube-dl.exe)) and place it in any location on their [PATH](https://en.wikipedia.org/wiki/PATH_%28variable%29) except for `%SYSTEMROOT%\System32` (e.g. **do not** put in `C:\Windows\System32`).
 
 You can also use pip:
 
@@ -1441,6 +1446,6 @@ It may sound strange, but some bug reports we receive are completely unrelated t
 
 # COPYRIGHT
 
-youtube-dl is released into the public domain by the copyright holders, under several conditions. Please read the [LICENSE](https://github.com/l1ving/youtube-dl/blob/master/LICENSE)
+youtube-dl is released into the public domain by the copyright holders.
 
 This README file was originally written by [Daniel Bolton](https://github.com/dbbolton) and is likewise released into the public domain.


### PR DESCRIPTION
Added mirror links to the README. Mirrored executable files were copied from the Internet Archive's version of the youtube-dl website, current as of October 14 2020.