### PR TITLE
[fix] The Makefile does not properly generate a release tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ youtube_dl/extractor/lazy_extractors.py: devscripts/make_lazy_extractors.py devs
 	$(PYTHON) devscripts/make_lazy_extractors.py $@
 
 VERSION = $(shell grep version youtube_dl/version.py |cut -f2 -d "'")
-youtube-dl.tar.gz: youtube-dl README.md README.txt youtube-dl.1 youtube-dl.bash-completion youtube-dl.zsh youtube-dl.fish ChangeLog AUTHORS
+youtube-dl.tar.gz: README.md README.txt youtube-dl.1 youtube-dl.bash-completion youtube-dl.zsh youtube-dl.fish ChangeLog AUTHORS
 	@tar -czf youtube-dl-$(VERSION).tar.gz --transform "s|^|youtube-dl-$(VERSION)/|" --owner 0 --group 0 \
 		--exclude '*.DS_Store' \
 		--exclude '*.kate-swp' \
@@ -133,4 +133,3 @@ youtube-dl.tar.gz: youtube-dl README.md README.txt youtube-dl.1 youtube-dl.bash-
 		ChangeLog AUTHORS LICENSE README.md README.txt \
 		Makefile MANIFEST.in youtube-dl.1 youtube-dl.bash-completion \
 		youtube-dl.zsh youtube-dl.fish setup.py setup.cfg \
-		youtube-dl

--- a/Makefile
+++ b/Makefile
@@ -117,8 +117,9 @@ _EXTRACTOR_FILES = $(shell find youtube_dl/extractor -iname '*.py' -and -not -in
 youtube_dl/extractor/lazy_extractors.py: devscripts/make_lazy_extractors.py devscripts/lazy_load_template.py $(_EXTRACTOR_FILES)
 	$(PYTHON) devscripts/make_lazy_extractors.py $@
 
+VERSION = $(shell grep version youtube_dl/version.py |cut -f2 -d "'")
 youtube-dl.tar.gz: youtube-dl README.md README.txt youtube-dl.1 youtube-dl.bash-completion youtube-dl.zsh youtube-dl.fish ChangeLog AUTHORS
-	@tar -czf youtube-dl.tar.gz --transform "s|^|youtube-dl/|" --owner 0 --group 0 \
+	@tar -czf youtube-dl-$(VERSION).tar.gz --transform "s|^|youtube-dl-$(VERSION)/|" --owner 0 --group 0 \
 		--exclude '*.DS_Store' \
 		--exclude '*.kate-swp' \
 		--exclude '*.pyc' \


### PR DESCRIPTION
### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [X] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The Makefile does not properly generate a release tarball. It has 2 problems:

1: The generated release tarball is not versioned.
When generating a tarball using «make youtube-dl.tar.gz» it does not generate a versioned tarball.
This Pull Request (PR) makes the tarball and the folder inside the tarball versioned.
(i.e. if the current version is 2020-10-30 the filename will be  youtube-dl-2020.10.30.tar.gz
and the folder inside will be youtube-dl-2020.10.30/)

2: The generated tarball also compiles and includes a _binary_ of the program.
This is not how it should be. Most distros currently have a rule in their packaging script that forcibly deletes the included binary.

This PR fixes these two problems.